### PR TITLE
Escalate self-parsing to derived clauses

### DIFF
--- a/bootpeg/peg.peg
+++ b/bootpeg/peg.peg
@@ -1,6 +1,6 @@
 # Full PEG+Actions parser
 spaces:
-    | [ " "+ ] { Discard() }
+    | " "* { Discard() }
 nothing:
     | "''" | '""' { Nothing() }
 anything:
@@ -26,6 +26,7 @@ sequence:
     | head=expr spaces tail=expr { chain(.head, .tail) }
 repeat:
     | expr=expr spaces "+" { Repeat(.expr) }
+    | expr=expr spaces "*" { either(Repeat(.expr), Nothing()) }
 capture:
     | name=identifier spaces "=" spaces expr=(reference | group) { Capture(.name, .expr) }
 reference:

--- a/bootpeg/peg.peg
+++ b/bootpeg/peg.peg
@@ -1,6 +1,6 @@
 # Full PEG+Actions parser
 spaces:
-    | " "+ | "" { Discard() }
+    | [ " "+ ] { Discard() }
 nothing:
     | "''" | '""' { Nothing() }
 anything:
@@ -16,6 +16,8 @@ literal:
 range:
     | first=literal spaces "-" spaces last=literal { Range(.first.value, .last.value) }
 
+optional:
+    | "[" spaces expr=expr spaces "]" { either(.expr, Nothing()) }
 group:
     | "(" spaces expr=expr spaces ")" { .expr }
 choice:
@@ -31,7 +33,7 @@ reference:
 reject:
     | "!" spaces expr=expr { Not(.expr) }
 expr:
-    | expr=(choice | sequence | repeat | capture | reference | group | range | literal | reject | anything | nothing) { .expr }
+    | expr=(choice | sequence | repeat | capture | reference | group | optional | range | literal | reject | anything | nothing) { .expr }
 
 rule:
     | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }

--- a/bootpeg/peg.peg
+++ b/bootpeg/peg.peg
@@ -1,6 +1,6 @@
 # Full PEG+Actions parser
 spaces:
-    | " "* { Discard() }
+    | " "*
 nothing:
     | "''" | '""' { Nothing() }
 anything:
@@ -38,6 +38,7 @@ expr:
 
 rule:
     | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }
+    | "|" spaces expr=expr { Rule(.expr, Action("Discard()")) }
 
 comment:
     | "#" ((!end_line) .)+ end_line { Discard() }

--- a/bootpeg/peg.peg
+++ b/bootpeg/peg.peg
@@ -1,0 +1,49 @@
+# Full PEG+Actions parser
+spaces:
+    | " "+ | "" { Discard() }
+nothing:
+    | "''" | '""' { Nothing() }
+anything:
+    | "." { Anything() }
+end_line:
+    | "
+" {Discard()}
+identifier:
+    | ( ( "a" - "z" ) | ( "A" - "Z" ) | "_" )+ { .* }
+
+literal:
+    | ('"' ( (!'"') . )+ '"') | ("'" ( (!"'") . )+ "'") { Literal(.*[1:-1]) }
+range:
+    | first=literal spaces "-" spaces last=literal { Range(.first.value, .last.value) }
+
+group:
+    | "(" spaces expr=expr spaces ")" { .expr }
+choice:
+    | try=expr spaces "|" spaces else=expr { either(.try, .else) }
+sequence:
+    | head=expr spaces tail=expr { chain(.head, .tail) }
+repeat:
+    | expr=expr spaces "+" { Repeat(.expr) }
+capture:
+    | name=identifier spaces "=" spaces expr=(reference | group) { Capture(.name, .expr) }
+reference:
+    | name=identifier { Reference(.name) }
+reject:
+    | "!" spaces expr=expr { Not(.expr) }
+expr:
+    | expr=(choice | sequence | repeat | capture | reference | group | range | literal | reject | anything | nothing) { .expr }
+
+rule:
+    | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }
+
+comment:
+    | "#" ((!end_line) .)+ end_line { Discard() }
+blank:
+    | spaces end_line { Discard() }
+define:
+    | name=identifier ":" spaces end_line rules=rules { (.name, .rules) }
+rules:
+    | " " spaces try=rule spaces end_line else=rules { either(.try, .else) }
+    | " " spaces rule=rule spaces end_line { .rule }
+top:
+    | ( define | comment | blank )+ { .* }

--- a/bootpeg/pika/act.py
+++ b/bootpeg/pika/act.py
@@ -104,7 +104,7 @@ class Rule(Clause[D]):
         return hash((self.action, self.sub_clauses))
 
     def __repr__(self):
-        return f"{self.__class__.__name__}({self.sub_clauses[0]!r})"
+        return f"{self.__class__.__name__}({self.sub_clauses[0]!r}, {self.action!r})"
 
     def __str__(self):
         return f"| {self.sub_clauses[0]} {self.action}"
@@ -145,6 +145,12 @@ class Action:
             rf"\1 {cls.mangle}\2", cls.unpack.sub(rf" {cls.mangle}all", literal)
         )
         return f'lambda {cls.mangle}all, {", ".join(names)}: {body}'
+
+    def __eq__(self, other):
+        return isinstance(other, Action) and self.literal == other.literal
+
+    def __hash__(self):
+        return hash(self.literal)
 
     def __str__(self):
         return f"{{{self.literal}}}"

--- a/bootpeg/pika/boot.peg
+++ b/bootpeg/pika/boot.peg
@@ -17,6 +17,8 @@ literal:
 range:
     | first=literal spaces "-" spaces last=literal { Range(.first.value, .last.value) }
 
+optional:
+    | "[" spaces expr=expr spaces "]" { either(.expr, Nothing()) }
 group:
     | "(" spaces expr=expr spaces ")" { .expr }
 choice:
@@ -32,7 +34,7 @@ reference:
 reject:
     | "!" spaces expr=expr { Not(.expr) }
 expr:
-    | expr=(choice | sequence | repeat | capture | reference | group | range | literal | reject | anything | nothing) { .expr }
+    | expr=(choice | sequence | repeat | capture | reference | group | optional | range | literal | reject | anything | nothing) { .expr }
 
 rule:
     | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }

--- a/bootpeg/pika/boot.peg
+++ b/bootpeg/pika/boot.peg
@@ -27,6 +27,7 @@ sequence:
     | head=expr spaces tail=expr { chain(.head, .tail) }
 repeat:
     | expr=expr spaces "+" { Repeat(.expr) }
+    | expr=expr spaces "*" { either(Repeat(.expr), Nothing()) }
 capture:
     | name=identifier spaces "=" spaces expr=(reference | group) { Capture(.name, .expr) }
 reference:

--- a/bootpeg/pika/boot.peg
+++ b/bootpeg/pika/boot.peg
@@ -14,6 +14,8 @@ identifier:
 
 literal:
     | ('"' ( (!'"') . )+ '"') | ("'" ( (!"'") . )+ "'") { Literal(.*[1:-1]) }
+range:
+    | first=literal spaces "-" spaces last=literal { Range(.first.value, .last.value) }
 
 group:
     | "(" spaces expr=expr spaces ")" { .expr }
@@ -30,12 +32,10 @@ reference:
 reject:
     | "!" spaces expr=expr { Not(.expr) }
 expr:
-    | expr=(choice | sequence | repeat | capture | reference | group | literal | reject | anything | nothing) { .expr }
+    | expr=(choice | sequence | repeat | capture | reference | group | range | literal | reject | anything | nothing) { .expr }
 
 rule:
-    | "|" spaces expr=expr spaces action=action { Rule(.expr, .action) }
-action:
-    | "{" body=(((!"}") .)+) "}" { Action(.body) }
+    | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }
 
 comment:
     | "#" ((!end_line) .)+ end_line { Discard() }

--- a/bootpeg/pika/boot.peg
+++ b/bootpeg/pika/boot.peg
@@ -39,6 +39,7 @@ expr:
 
 rule:
     | "|" spaces expr=expr spaces "{" body=(((!"}") .)+) "}" { Rule(.expr, Action(.body)) }
+    | "|" spaces expr=expr { Rule(.expr, Action("Discard()")) }
 
 comment:
     | "#" ((!end_line) .)+ end_line { Discard() }

--- a/bootpeg/pika/boot.py
+++ b/bootpeg/pika/boot.py
@@ -55,6 +55,8 @@ def report_matches(memo: MemoTable):
         if position not in longest_matches or longest_matches[position].length < length:
             longest_matches[position] = match
     report_pos = min(longest_matches)
+    print(*(' ' if i % 10 else i % 1000 // 100 for i in range(len(memo.source))), sep="")
+    print(*(' ' if i % 10 else i % 100 // 10 for i in range(len(memo.source))), sep="")
     print(*(i % 10 for i in range(len(memo.source))), sep="")
     print(memo.source.translate(ascii_escapes))
     while report_pos < len(memo.source):

--- a/bootpeg/pika/boot.py
+++ b/bootpeg/pika/boot.py
@@ -22,6 +22,7 @@ from .front import (
     transform,
     chain,
     either,
+    Range,
 )
 
 
@@ -105,6 +106,7 @@ namespace = {
         Rule,
         Action,
         Discard,
+        Range,
     )
 }
 

--- a/bootpeg/pika/boot.py
+++ b/bootpeg/pika/boot.py
@@ -275,6 +275,7 @@ parser = Parser(
     ),
 )
 boot_path = pathlib.Path(__file__).parent / "boot.peg"
+full_path = pathlib.Path(__file__).parent.parent / "peg.peg"
 
 
 def boot(base_parser: Parser, source: str) -> Parser:
@@ -289,11 +290,19 @@ def boot(base_parser: Parser, source: str) -> Parser:
 
 if __name__ == "__main__":
     display(parser)
-    for iteration in range(5):
+    for iteration in range(2):
         with open(boot_path) as boot_peg:
             print("Generation:", iteration)
             parser = range_parse(
                 boot_peg.read(),
+                parser,
+            )
+            display(parser)
+    for iteration in range(2, 4):
+        with open(full_path) as base_peg:
+            print("Generation:", iteration)
+            parser = range_parse(
+                base_peg.read(),
                 parser,
             )
             display(parser)

--- a/bootpeg/pika/boot.py
+++ b/bootpeg/pika/boot.py
@@ -56,8 +56,10 @@ def report_matches(memo: MemoTable):
         if position not in longest_matches or longest_matches[position].length < length:
             longest_matches[position] = match
     report_pos = min(longest_matches)
-    print(*(' ' if i % 10 else i % 1000 // 100 for i in range(len(memo.source))), sep="")
-    print(*(' ' if i % 10 else i % 100 // 10 for i in range(len(memo.source))), sep="")
+    print(
+        *(" " if i % 10 else i % 1000 // 100 for i in range(len(memo.source))), sep=""
+    )
+    print(*(" " if i % 10 else i % 100 // 10 for i in range(len(memo.source))), sep="")
     print(*(i % 10 for i in range(len(memo.source))), sep="")
     print(memo.source.translate(ascii_escapes))
     while report_pos < len(memo.source):

--- a/bootpeg/pika/front.py
+++ b/bootpeg/pika/front.py
@@ -83,7 +83,11 @@ class Range(Terminal[D]):
         return None
 
     def __eq__(self, other):
-        return isinstance(other, Range) and self.first == other.first and self.last == other.last
+        return (
+            isinstance(other, Range)
+            and self.first == other.first
+            and self.last == other.last
+        )
 
     def __hash__(self):
         return hash((self.first, self.last))

--- a/bootpeg/pika/front.py
+++ b/bootpeg/pika/front.py
@@ -1,4 +1,3 @@
-from typing import NamedTuple, Callable
 from .peg import (
     Literal,
     Sequence,

--- a/bootpeg/pika/front.py
+++ b/bootpeg/pika/front.py
@@ -1,3 +1,4 @@
+from typing import NamedTuple, Callable
 from .peg import (
     Literal,
     Sequence,
@@ -8,6 +9,10 @@ from .peg import (
     Repeat,
     Reference,
     Parser,
+    MemoTable,
+    Match,
+    Terminal,
+    D,
 )
 from .act import Debug, Capture, Rule, transform, Action, Discard
 
@@ -32,6 +37,7 @@ __all__ = [
     # helpers
     "chain",
     "either",
+    "Range",
 ]
 
 
@@ -55,3 +61,36 @@ def either(left, right) -> Choice:
     if isinstance(right, Choice):
         return Choice(left, *right.sub_clauses)
     return Choice(left, right)
+
+
+class Range(Terminal[D]):
+    """
+    A terminal matching anything between two bounds inclusively
+    """
+
+    __slots__ = ("first", "last", "_length")
+    maybe_zero = False
+
+    def __init__(self, first: D, last: D):
+        assert len(first) == len(last) > 0
+        self.first = first
+        self.last = last
+        self._length = len(first)
+
+    def match(self, source: D, at: int, memo: MemoTable):
+        candidate = source[at : at + self._length]
+        if len(candidate) == self._length and self.first <= candidate <= self.last:
+            return Match(self._length, (), at, self)
+        return None
+
+    def __eq__(self, other):
+        return isinstance(other, Range) and self.first == other.first and self.last == other.last
+
+    def __hash__(self):
+        return hash((self.first, self.last))
+
+    def __repr__(self):
+        return f"{self.__class__.__name__}({self.first!r}, {self.last!r})"
+
+    def __str__(self):
+        return f"{self.first!r} - {self.last!r}"

--- a/bootpeg/pika/peg.py
+++ b/bootpeg/pika/peg.py
@@ -379,7 +379,7 @@ class Repeat(Clause[D]):
             )
 
     def __eq__(self, other):
-        return isinstance(other, Not) and self._sub_clause == other._sub_clause
+        return isinstance(other, Repeat) and self._sub_clause == other._sub_clause
 
     def __hash__(self):
         return hash(self.sub_clauses)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -15,3 +15,12 @@ def test_escalate():
     parser = boot.boot(boot.parser, boot_peg)
     for _ in range(2):
         parser = boot.boot(parser, full_peg)
+
+
+def test_features():
+    boot_peg = boot.boot_path.read_text()
+    full_peg = boot.full_path.read_text()
+    parser = boot.boot(boot.boot(boot.parser, boot_peg), full_peg)
+    opt_repeat = boot.boot(parser, 'rule:\n    | [ " "+ ]\n').clauses['rule']
+    non_repeat = boot.boot(parser, 'rule:\n    | " "*\n').clauses['rule']
+    assert opt_repeat == non_repeat

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -2,8 +2,16 @@ from bootpeg.pika import boot
 
 
 def test_bootstrap():
-    with open(boot.boot_path) as boot_peg_stream:
-        boot_peg = boot_peg_stream.read()
+    boot_peg = boot.boot_path.read_text()
     parser = boot.parser
+    # ensure each parser handles itself
     for _ in range(2):
         parser = boot.boot(parser, boot_peg)
+
+
+def test_escalate():
+    boot_peg = boot.boot_path.read_text()
+    full_peg = boot.full_path.read_text()
+    parser = boot.boot(boot.parser, boot_peg)
+    for _ in range(2):
+        parser = boot.boot(parser, full_peg)

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -21,6 +21,6 @@ def test_features():
     boot_peg = boot.boot_path.read_text()
     full_peg = boot.full_path.read_text()
     parser = boot.boot(boot.boot(boot.parser, boot_peg), full_peg)
-    opt_repeat = boot.boot(parser, 'rule:\n    | [ " "+ ]\n').clauses['rule']
-    non_repeat = boot.boot(parser, 'rule:\n    | " "*\n').clauses['rule']
-    assert opt_repeat == non_repeat
+    opt_repeat = boot.boot(parser, 'rule:\n    | [ " "+ ]\n')
+    non_repeat = boot.boot(parser, 'rule:\n    | " "*\n')
+    assert opt_repeat.clauses == non_repeat.clauses


### PR DESCRIPTION
Provide "derived clauses" from base PEG clauses.

* [x] ``[ e ]: e / ε``
* [x] ``e*:  e+ / ε``
* [x] ~~``&e: !!e``~~  deferred to #9

Also adds a literal range to reduce literals and a default-discard action.

* [x] `` "a" - "z": "a" | "b" | ... | "y" | "z"``
* [x] `` | a: | a {Discard()}``