### PR TITLE
Verify action parameter capturing

### DIFF
--- a/bootpeg/pika/act.py
+++ b/bootpeg/pika/act.py
@@ -98,24 +98,20 @@ class ActionCaptureError(TypeError):
         msg = f"extra {', '.join(map(repr, extra))}" if extra else ""
         msg += " and " if extra and missing else ""
         msg += f"missing {', '.join(map(repr, missing))}" if missing else ""
-        super().__init__(
-            f"{msg} captures: {self.rule}"
-        )
+        super().__init__(f"{msg} captures: {self.rule}")
 
 
 class Rule(Clause[D]):
     __slots__ = ("sub_clauses", "action", "_hash")
 
-    def __init__(self, sub_clause: Clause[D], action: 'Action'):
+    def __init__(self, sub_clause: Clause[D], action: "Action"):
         self.sub_clauses = (sub_clause,)
         self.action = action
         self._hash = None
         self._verify_captures()
 
     def _verify_captures(self):
-        captured_names = {
-            capture.name for capture in captures(self.sub_clauses[0])
-        }
+        captured_names = {capture.name for capture in captures(self.sub_clauses[0])}
         if captured_names.symmetric_difference(self.action.parameters):
             additional = captured_names.difference(self.action.parameters)
             missing = set(self.action.parameters) - captured_names

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,3 +1,5 @@
+import pytest
+
 from bootpeg.pika import boot
 
 
@@ -24,3 +26,7 @@ def test_features():
     opt_repeat = boot.boot(parser, 'rule:\n    | [ " "+ ]\n')
     non_repeat = boot.boot(parser, 'rule:\n    | " "*\n')
     assert opt_repeat.clauses == non_repeat.clauses
+    with pytest.raises(TypeError):
+        boot.boot(parser, 'rule:\n    | [ " "+ ] { .missing }\n')
+    with pytest.raises(TypeError):
+        boot.boot(parser, 'rule:\n    | extra=([ " "+ ]) { () }\n')


### PR DESCRIPTION
This PR adds a check to ``Rule`` to ensure that all parameters required by the action may be captured. The check does not take into account optional captures, which would require more thorough commitment (e.g. decide on defaults).

Closes #4.