### PR TITLE
API for module parser "import"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,10 +27,16 @@
 `bootpeg` is a PEG parser for creating parsers – including itself.
 By default, it supports a modified EBNF with actions akin to `PEP 617`_.
 
-.. code-block:: bash
+.. code-block:: python3
 
-    # memoizing bottom-up PEG parser
-    $ python3 -m bootpeg.pika.boot
+   >>> # recreate the bootpeg parser from itself
+   >>> from bootpeg.api import import_parser, PikaActions
+   >>> from bootpeg.grammars import bpeg
+   >>> parse_bpeg = bpeg.parse
+   >>> for _ in range(5):
+   ...     parse_bpeg = import_parser(
+   ...         bpeg.__name__, actions=PikaActions, dialect=parse_bpeg
+   ...     )
 
 Unlike most other Python PEG parsers which are top-down parsers,
 `bootpeg` provides a bottom-up `Pika parser`_:

--- a/bootpeg/api.py
+++ b/bootpeg/api.py
@@ -39,16 +39,16 @@ class Actions(Generic[D, T, R]):
 #: :py:class:`~.Actions` to construct a Pika parser
 PikaActions: Actions[str, Union[str, Clause[str]], Parser] = Actions(
     names=pika_namespace,
-    post=lambda *args, **kwargs: Parser(
-        "top",
+    post=lambda *args, top="top", **kwargs: Parser(
+        top,
         **{name: clause for name, clause in args[0]},
     ),
 )
 
 
-def parse(source: D, parser: Parser[D], actions: Actions[D, T, R]) -> T:
+def parse(source: D, parser: Parser[D], actions: Actions[D, T, R], **kwargs) -> T:
     """Parse a ``source`` with a given ``parser`` and ``actions``"""
     head, memo = parser.parse(source)
     assert head.length == len(source), f"matched {head.length} of {len(source)}"
-    args, kwargs = transform(head, memo, actions.names)
-    return actions.post(*args, **kwargs)
+    pos_captures, kw_captures = transform(head, memo, actions.names)
+    return actions.post(*pos_captures, **kw_captures, **kwargs)

--- a/bootpeg/grammars/bpeg.py
+++ b/bootpeg/grammars/bpeg.py
@@ -21,7 +21,7 @@ from ..pika.peg import (
 from ..pika.act import Capture, Rule
 from ..pika.front import Range, Delimited
 from ..pika.boot import bootpeg, boot
-from ..api import Actions, PikaActions, parse as generic_parse
+from ..api import Actions, PikaActions, import_parser
 
 
 @singledispatch
@@ -102,19 +102,11 @@ def unparse_delimited(clause: Delimited, top=True) -> str:
     return f"{unparse(first, top=False)} :: {unparse(last, top=False)}"
 
 
-_parser_cache: Optional[Parser] = None
 grammar_path = Path(__file__).parent / "bpeg.bpeg"
 
 
-def _get_parser() -> Parser:
-    global _parser_cache
-    if _parser_cache is None:
-        parser = bootpeg()
-        # TODO: does translating twice offer any benefit?
-        parser = boot(parser, grammar_path.read_text())
-        _parser_cache = parser
-    return _parser_cache
+def boot_dialect(source):
+    return boot(bootpeg(), source)
 
 
-def parse(source, actions: Actions = PikaActions, **kwargs):
-    return generic_parse(source, _get_parser(), actions, **kwargs)
+parse = import_parser(__name__, actions=PikaActions, dialect=boot_dialect)

--- a/bootpeg/grammars/bpeg.py
+++ b/bootpeg/grammars/bpeg.py
@@ -1,9 +1,8 @@
 """
 The default bootpeg grammar
 """
-from typing import Union, Optional
+from typing import Union
 from functools import singledispatch
-from pathlib import Path
 
 from ..pika.peg import (
     Clause,
@@ -21,7 +20,7 @@ from ..pika.peg import (
 from ..pika.act import Capture, Rule
 from ..pika.front import Range, Delimited
 from ..pika.boot import bootpeg, boot
-from ..api import Actions, PikaActions, import_parser
+from ..api import PikaActions, import_parser
 
 
 @singledispatch
@@ -100,9 +99,6 @@ def unparse_range(clause: Range, top=True) -> str:
 def unparse_delimited(clause: Delimited, top=True) -> str:
     first, last = clause.sub_clauses
     return f"{unparse(first, top=False)} :: {unparse(last, top=False)}"
-
-
-grammar_path = Path(__file__).parent / "bpeg.bpeg"
 
 
 def boot_dialect(source):

--- a/bootpeg/grammars/bpeg.py
+++ b/bootpeg/grammars/bpeg.py
@@ -116,5 +116,5 @@ def _get_parser() -> Parser:
     return _parser_cache
 
 
-def parse(source, actions: Actions = PikaActions):
-    return generic_parse(source, _get_parser(), actions)
+def parse(source, actions: Actions = PikaActions, **kwargs):
+    return generic_parse(source, _get_parser(), actions, **kwargs)

--- a/bootpeg/grammars/peg.py
+++ b/bootpeg/grammars/peg.py
@@ -112,5 +112,5 @@ def _get_parser() -> Parser:
     return _parser_cache
 
 
-def parse(source, actions: Actions = PikaActions):
-    return generic_parse(source, _get_parser(), actions)
+def parse(source, actions: Actions = PikaActions, **kwargs):
+    return generic_parse(source, _get_parser(), actions, **kwargs)

--- a/bootpeg/grammars/peg.py
+++ b/bootpeg/grammars/peg.py
@@ -20,9 +20,6 @@ from ..pika.front import Range, Delimited
 from ..api import PikaActions, import_parser
 from . import bpeg
 
-_parser_cache: Optional[Parser] = None
-grammar_path = Path(__file__).parent / "peg.bpeg"
-
 
 @singledispatch
 def unparse(clause: Union[Clause, Parser], top=True) -> str:
@@ -102,14 +99,6 @@ def unparse_delimited(clause: Delimited, top=True) -> str:
     first, last = (unparse(c, top=False) for c in clause.sub_clauses)
     children = f"{first} (!{last} .)* {last}"
     return f"({children})" if not top else children
-
-
-def _get_parser() -> Parser:
-    global _parser_cache
-    if _parser_cache is None:
-        parser = bpeg.parse(grammar_path.read_text())
-        _parser_cache = parser
-    return _parser_cache
 
 
 parse = import_parser(__name__, actions=PikaActions, dialect=bpeg)

--- a/bootpeg/grammars/peg.py
+++ b/bootpeg/grammars/peg.py
@@ -17,7 +17,7 @@ from ..pika.peg import (
 )
 from ..pika.act import Capture, Rule
 from ..pika.front import Range, Delimited
-from ..api import Actions, PikaActions, parse as generic_parse
+from ..api import Actions, PikaActions, import_parser
 from . import bpeg
 
 _parser_cache: Optional[Parser] = None
@@ -112,5 +112,4 @@ def _get_parser() -> Parser:
     return _parser_cache
 
 
-def parse(source, actions: Actions = PikaActions, **kwargs):
-    return generic_parse(source, _get_parser(), actions, **kwargs)
+parse = import_parser(__name__, actions=PikaActions, dialect=bpeg)

--- a/bootpeg/grammars/peg.py
+++ b/bootpeg/grammars/peg.py
@@ -17,7 +17,7 @@ from ..pika.peg import (
 )
 from ..pika.act import Capture, Rule
 from ..pika.front import Range, Delimited
-from ..api import Actions, PikaActions, import_parser
+from ..api import PikaActions, import_parser
 from . import bpeg
 
 _parser_cache: Optional[Parser] = None

--- a/bootpeg/grammars/peg.py
+++ b/bootpeg/grammars/peg.py
@@ -1,6 +1,5 @@
-from typing import Optional, Union
+from typing import Union
 from functools import singledispatch
-from pathlib import Path
 
 from ..pika.peg import (
     Clause,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,11 +43,14 @@ By default, it supports a modified EBNF with actions akin to `PEP 617`_.
 
 .. code-block:: python3
 
-   >>> # recreate the bootpeg parser
+   >>> # recreate the bootpeg parser from itself
+   >>> from bootpeg.api import import_parser, PikaActions
    >>> from bootpeg.grammars import bpeg
-   >>> bpeg.parse(
-   ...     bpeg.grammar_path.read_text()
-   ... )
+   >>> parse_bpeg = bpeg.parse
+   >>> for _ in range(5):
+   ...     parse_bpeg = import_parser(
+   ...         bpeg.__name__, actions=PikaActions, dialect=parse_bpeg
+   ...     )
 
 Unlike most other Python PEG parsers which are top-down parsers,
 `bootpeg` provides a bottom-up `Pika parser`_:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
 ]
-requires = ["typing_extensions"]
+requires = ["typing_extensions", "importlib_resources"]
 
 [tool.flit.metadata.requires-extra]
 test = [

--- a/tests/test_grammars/test_peg.py
+++ b/tests/test_grammars/test_peg.py
@@ -118,8 +118,7 @@ EndOfFile <- !.
 
 def test_parse_reference():
     """Parse the PEG reference grammar"""
-    parser = peg.parse(peg_grammar)
-    parser.top = "Grammar"
+    parser = peg.parse(peg_grammar, top="Grammar")
     assert parser.parse(peg_grammar)
 
 


### PR DESCRIPTION
This PR adds a means to construct a full parser for a module-like path.

* [ ] Basic interface to load parsers from module-like paths
* [ ] Builtin ``grammars`` use import interface
* [ ] Basic documentation

Closes #26.